### PR TITLE
Support high point value questions.

### DIFF
--- a/quizzes/quizwiz/install/qw-standalone.user.js
+++ b/quizzes/quizwiz/install/qw-standalone.user.js
@@ -1146,7 +1146,7 @@
         var points;
         var pts = e.querySelector('div.user_points span.points.question_points').textContent;
         if (pts) {
-          var match = /\/ ([0-9.]+)$/.exec(pts);
+          var match = /\/ ([0-9.,]+)$/.exec(pts);
           if (match) {
             points = match[1];
           }

--- a/quizzes/quizwiz/src/qw-engine.js
+++ b/quizzes/quizwiz/src/qw-engine.js
@@ -1111,7 +1111,7 @@ var QuizWiz = function(config) {
       var points;
       var pts = e.querySelector('div.user_points span.points.question_points').textContent;
       if (pts) {
-        var match = /\/ ([0-9.]+)$/.exec(pts);
+        var match = /\/ ([0-9.,]+)$/.exec(pts);
         if (match) {
           points = match[1];
         }


### PR DESCRIPTION
As an Earth science instructor, I grade my classes out of a possible 4.54 billion points (the age of the Earth) -- which means that most of my quiz questions are on the order of ~4 million points. This patch enables quizwiz to parse point values with commas.